### PR TITLE
Could com.ruoyi:ruoyi-common-datasource:3.6.2 drop off redundant dependencies?

### DIFF
--- a/ruoyi-common/ruoyi-common-datasource/pom.xml
+++ b/ruoyi-common/ruoyi-common-datasource/pom.xml
@@ -17,19 +17,137 @@
 
     <dependencies>
 
-        <!-- Druid -->
-        <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>druid-spring-boot-starter</artifactId>
-            <version>${druid.version}</version>
-        </dependency>
-
         <!-- Dynamic DataSource -->
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>dynamic-datasource-spring-boot-starter</artifactId>
             <version>${dynamic-ds.version}</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>slf4j-api</artifactId>
+                   <groupId>org.slf4j</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-boot-autoconfigure</artifactId>
+                   <groupId>org.springframework.boot</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-core</artifactId>
+                   <groupId>org.springframework</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-boot</artifactId>
+                   <groupId>org.springframework.boot</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>aspectjweaver</artifactId>
+                   <groupId>org.aspectj</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-boot-starter</artifactId>
+                   <groupId>org.springframework.boot</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>jakarta.annotation-api</artifactId>
+                   <groupId>jakarta.annotation</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-jdbc</artifactId>
+                   <groupId>org.springframework</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-tx</artifactId>
+                   <groupId>org.springframework</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>snakeyaml</artifactId>
+                   <groupId>org.yaml</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-boot-starter-aop</artifactId>
+                   <groupId>org.springframework.boot</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>logback-core</artifactId>
+                   <groupId>ch.qos.logback</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-boot-starter-logging</artifactId>
+                   <groupId>org.springframework.boot</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-beans</artifactId>
+                   <groupId>org.springframework</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>log4j-api</artifactId>
+                   <groupId>org.apache.logging.log4j</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>logback-classic</artifactId>
+                   <groupId>ch.qos.logback</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-aop</artifactId>
+                   <groupId>org.springframework</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-boot-starter-jdbc</artifactId>
+                   <groupId>org.springframework.boot</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>log4j-to-slf4j</artifactId>
+                   <groupId>org.apache.logging.log4j</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>HikariCP</artifactId>
+                   <groupId>com.zaxxer</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>jul-to-slf4j</artifactId>
+                   <groupId>org.slf4j</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-bootstrap</artifactId>
+            <version>3.1.5</version>
+            <scope>provided</scope>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>spring-cloud-starter</artifactId>
+                   <groupId>org.springframework.cloud</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>bcpkix-jdk15on</artifactId>
+                   <groupId>org.bouncycastle</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>bcprov-jdk15on</artifactId>
+                   <groupId>org.bouncycastle</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-cloud-context</artifactId>
+                   <groupId>org.springframework.cloud</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-security-rsa</artifactId>
+                   <groupId>org.springframework.security</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-cloud-commons</artifactId>
+                   <groupId>org.springframework.cloud</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>spring-security-crypto</artifactId>
+                   <groupId>org.springframework.security</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>bcutil-jdk15on</artifactId>
+                   <groupId>org.bouncycastle</groupId>
+                 </exclusion>
+             </exclusions>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/126549527/223661145-c20fdc13-23ad-4944-aa1c-90431dce54ab.png)
![2](https://user-images.githubusercontent.com/126549527/223661157-4dfc04ed-3552-4fdf-87ac-77b42584d5c2.png)

Hi, I found that **_com.ruoyi:ruoyi-common-datasource:3.6.2_**’s pom file introduced **_36_** dependencies. However, among them, **_35_** libraries (**_97%_** have not been used by your project), the redundant dependencies are listed below. 

More seriously, **_1_** redundant dependency contains security vulnerabilities (vulnerable libraries). 

**_1_**  redundant library has not been maintained by developers for more than **_3_** years（outdated dependencies）. 

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with security vulnerabilities and outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding) , and validated that they have not been used by the client code.
 
This PR **_com.ruoyi:ruoyi-common-datasource:3.6.2_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
      com.alibaba:druid-spring-boot-starter:1.2.16:compile [20 KB]
#### Redundant indirect dependencies:
         org.aspectj:aspectjweaver:1.9.7:compile [1 MB]
         org.springframework:spring-context:5.3.24:compile [1 MB]
         org.springframework.boot:spring-boot-starter:2.7.7:compile [4 KB]
         org.slf4j:slf4j-api:1.7.36:compile [40 KB]
         jakarta.annotation:jakarta.annotation-api:1.3.5:compile [24 KB]
         org.springframework:spring-jdbc:5.3.24:compile [418 KB]
         org.springframework:spring-tx:5.3.24:compile [325 KB]
         org.springframework:spring-expression:5.3.24:compile [282 KB]
         org.yaml:snakeyaml:1.30:compile [323 KB]
         org.springframework.boot:spring-boot-starter-aop:2.7.7:compile [4 KB]
         ch.qos.logback:logback-core:1.2.11:compile [438 KB]
         org.springframework.boot:spring-boot-starter-logging:2.7.7:compile [4 KB]
         org.springframework.boot:spring-boot:2.7.7:compile [1 MB]
         org.springframework:spring-beans:5.3.24:compile [686 KB]
         org.apache.logging.log4j:log4j-api:2.17.2:compile [295 KB]
         ch.qos.logback:logback-classic:1.2.11:compile [226 KB]
         com.alibaba:druid:1.2.16:compile [3 MB]
         org.springframework:spring-aop:5.3.24:compile [373 KB]
         org.springframework.boot:spring-boot-starter-jdbc:2.7.7:compile [4 KB]
         org.apache.logging.log4j:log4j-to-slf4j:2.17.2:compile [17 KB]
         org.springframework:spring-jcl:5.3.24:compile [23 KB]
         org.springframework:spring-core:5.3.24:compile [1 MB]
         com.zaxxer:HikariCP:4.0.3:compile [155 KB]
         org.springframework.boot:spring-boot-autoconfigure:2.7.7:compile [1 MB]
         org.slf4j:jul-to-slf4j:1.7.36:compile [4 KB]  
#### Redundant direct dependencies inherited from parent pom:
         org.springframework.cloud:spring-cloud-starter-bootstrap:3.1.5:compile [3 KB]
#### Redundant indirect dependencies inherited from parent pom:
         org.springframework.cloud:spring-cloud-starter:3.1.5:compile [2 KB]
         org.bouncycastle:bcpkix-jdk15on:1.69:compile [887 KB]
         org.bouncycastle:bcprov-jdk15on:1.69:compile [5 MB]
         org.springframework.cloud:spring-cloud-context:3.1.5:compile [154 KB]
         org.springframework.security:spring-security-rsa:1.0.11.RELEASE:compile [19 KB]
         org.springframework.cloud:spring-cloud-commons:3.1.5:compile [253 KB]
         org.springframework.security:spring-security-crypto:5.7.6:compile [80 KB]
         org.bouncycastle:bcutil-jdk15on:1.69:compile [351 KB]

## Vulnerable libraries
org.yaml:snakeyaml:1.30 (CVE-2022-25857)

## Outdated dependencies
jakarta.annotation:jakarta.annotation-api:1.3.5 (**_1314_** days without maintenance) 
