### PR TITLE
使用基于 docker/mysql/dockerfile 构建的自定义镜像，而不是官方的 mysql:5.7 镜像。

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - ruoyi-mysql
   ruoyi-mysql:
     container_name: ruoyi-mysql
-    image: mysql:5.7
     build:
       context: ./mysql
     ports:


### PR DESCRIPTION
主要解决的问题是：ruoyi-mysql 服务第一次启动时，没有自动执行 docker/mysql/db/ 目录下的 sql 脚本，导致 ruoyi-nacos 服务找不到 ry-config 数据库，启动失败。