### PR TITLE
dockercompse的mysql启动时，sql文件没有被执行

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - ./mysql/conf:/etc/mysql/conf.d
       - ./mysql/logs:/logs
       - ./mysql/data:/var/lib/mysql
+      - ./mysql/db:/docker-entrypoint-initdb.d
     command: [
           'mysqld',
           '--innodb-buffer-pool-size=80M',

--- a/docker/mysql/dockerfile
+++ b/docker/mysql/dockerfile
@@ -2,6 +2,3 @@
 FROM mysql:5.7
 # author
 MAINTAINER ruoyi
-
-# 执行sql脚本
-ADD ./db/*.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
# 执行sql脚本
ADD ./db/*.sql /docker-entrypoint-initdb.d/   并没有把文件正确挂载

改为在docker-compose.yml文件中         
 volumes:
    - ./mysql/db:/docker-entrypoint-initdb.d  # 挂载 SQL 脚本目录