### PR TITLE
Update application.properties

### DIFF
--- a/docker/nacos/conf/application.properties
+++ b/docker/nacos/conf/application.properties
@@ -1,4 +1,5 @@
-spring.datasource.platform=mysql
+#spring.datasource.platform=mysql
+spring.sql.init.platform=mysql
 db.num=1
 db.url.0=jdbc:mysql://ruoyi-mysql:3306/ry-config?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC
 db.user=root


### PR DESCRIPTION
nacos日志显示异常，当使用external 时，虽然实现了连接外部mysql的功能，但是日志上显示embedded（使用内嵌MySQL），改成这个配置日志显示就正常了 spring.sql.init.platform=mysql